### PR TITLE
Named some anonymous structs. Mimicking existing naming conventions

### DIFF
--- a/mavlink_types.h
+++ b/mavlink_types.h
@@ -80,8 +80,8 @@ typedef struct param_union {
  * and the bits pulled out using the shifts/masks.
 */
 MAVPACKED(
-typedef union {
-    struct {
+typedef union __mavlink_param_union_double{
+    struct __data{
         uint8_t is_double:1;
         uint8_t mavlink_type:7;
         union {


### PR DESCRIPTION
Compiling a project with c++11 leads to warnings about anonymous structs. To fix this, I've added names to some structs that were missing them. I mimicked the existing naming conventions established elsewhere in the code.